### PR TITLE
Update brycewray.com in sites.yml

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -390,8 +390,8 @@
 
 - domain: brycewray.com
   url: https://www.brycewray.com/
-  size: 92.3
-  last_checked: 2022-05-26
+  size: 103.0
+  last_checked: 2022-06-27
 
 - domain: buchh.org
   url: https://buchh.org/


### PR DESCRIPTION
Using a web font again, so uncompressed size per GTMetrix is now 103.0 KB (https://gtmetrix.com/reports/www.brycewray.com/7Q032UlL/).

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain **size**
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (512kb.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] I used the uncompressed size of the site
- [x] I have included a link to the GTMetrix report
- [x] The domain is in the correct alphabetical order
- [x] This site is not a ultra lightweight site
- [ ] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://512kb.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

```
- domain: brycewray.com
  url: https://www.brycewray.com
  size: 103.0
  last_checked: 2022-06-27
```

GTMetrix Report: 
https://gtmetrix.com/reports/www.brycewray.com/7Q032UlL/